### PR TITLE
Added 4x4 Matrix Class

### DIFF
--- a/adafruit_ht16k33/matrix.py
+++ b/adafruit_ht16k33/matrix.py
@@ -76,3 +76,14 @@ class Matrix8x8x2(HT16K33):
         for i in range(8):
             self._set_buffer(i * 2, fill1)
             self._set_buffer(i * 2 + 1, fill2)
+            
+class Matrix4x4(HT16K33):
+    """A single 4x4 matrix."""
+    def pixel(self, x, y, color=None):
+        """Get or set the color of a given pixel."""
+        if not 0 <= x <= 3:
+            return None
+        if not 0 <= y <= 3:
+            return None
+        x = (x - 1) % 4
+        return super()._pixel(x, y, color)

--- a/adafruit_ht16k33/matrix.py
+++ b/adafruit_ht16k33/matrix.py
@@ -76,7 +76,7 @@ class Matrix8x8x2(HT16K33):
         for i in range(8):
             self._set_buffer(i * 2, fill1)
             self._set_buffer(i * 2 + 1, fill2)
-            
+
 class Matrix4x4(HT16K33):
     """A single 4x4 matrix."""
     def pixel(self, x, y, color=None):


### PR DESCRIPTION
Added a 4x4 matrix class. intended use is currently for Adafruit Trellis board (PID: 1616), but can obviously be used beyond. I've only included a single matrix at this time. Can work on extras later (4x4x2, 4x4x4).

Trellis link: https://www.adafruit.com/product/1616