### PR TITLE
Updates for segment displays

### DIFF
--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -149,6 +149,7 @@ NUMBERS = (
 class Seg14x4(HT16K33):
     """Alpha-numeric, 14-segment display."""
     def print(self, value):
+        """Print the value to the display."""
         if isinstance(value, (str)):
             self._text(value)
         elif isinstance(value, (int, float)):
@@ -211,6 +212,7 @@ class Seg7x4(Seg14x4):
     POSITIONS = [0, 2, 6, 8] #  The positions of characters.
 
     def print(self, value):
+        """Print the value to the display."""
         if isinstance(value, (int, float)):
             self._number(value)
         else:

--- a/examples/segments.py
+++ b/examples/segments.py
@@ -28,12 +28,12 @@ display.fill(0)
 display.show()
 
 # Set the first character to '1':
-display.put('1', 0)
+display[0] = '1'
 # Set the second character to '2':
-display.put('2', 1)
+display[1] = '2'
 # Set the third character to 'A':
-display.put('A', 2)
+display[2] = 'A'
 # Set the forth character to 'B':
-display.put('B', 3)
+display[3] = 'B'
 # Make sure to call show to see the changes above on the display!
 display.show()


### PR DESCRIPTION
Setting the segment display output now works like this:
```python
# for text
disp.print("BEEF")
# for numbers
disp.print(3.14)
# for individual digit
disp[2] = "G"
```
All of the above works for the alpha-numeric display `Seg14x4`, only numbers can be used with `Seg7x4`.