### PR TITLE
Add support for 1.2" 4-Digit 7-Segment Displays 

### DIFF
--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -256,3 +256,29 @@ class Seg7x4(Seg14x4):
         else:
             return
         self._set_buffer(index, NUMBERS[character])
+
+class BigSeg7x4(Seg7x4):
+    """Numeric 7-segment display. It has the same methods as the alphanumeric display, but only
+       supports displaying a limited set of characters."""
+    def __init__(self, i2c, address=0x70, auto_write=True):
+        super().__init__(i2c, address, auto_write)
+
+    @property
+    def ampm(self):
+        return (self._get_buffer(0x04) & 0x10) >> 4
+
+    @ampm.setter
+    def ampm(self, value):
+        current = self._get_buffer(0x04)
+        if value:
+            self._set_buffer(0x04, current | 0x10)
+        else:
+            self._set_buffer(0x04, current & ~0x10)
+        if self._auto_write:
+            self.show()
+
+    def print(self, value):
+        ampm = self.ampm
+        super().print(value)
+        if ampm:
+            self.ampm = ampm

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -261,7 +261,7 @@ class BigSeg7x4(Seg7x4):
        supports displaying a limited set of characters."""
     def __init__(self, i2c, address=0x70, auto_write=True):
         super().__init__(i2c, address, auto_write)
-        self.colon = Colon(self, 2)
+        self.colon = Colon(self, 2)    
 
     @property
     def ampm(self):

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -261,10 +261,11 @@ class BigSeg7x4(Seg7x4):
        supports displaying a limited set of characters."""
     def __init__(self, i2c, address=0x70, auto_write=True):
         super().__init__(i2c, address, auto_write)
-        self.colon = Colon(self, 2)    
+        self.colon = Colon(self, 2)
 
     @property
     def ampm(self):
+        """The AM/PM indicator."""
         return bool(self._get_buffer(0x04) & 0x10)
 
     @ampm.setter

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -277,14 +277,6 @@ class BigSeg7x4(Seg7x4):
         if self._auto_write:
             self.show()
 
-    """need something like this to keep ampm indicator
-       and colons from being turned off with print?"""
-    # def print(self, value):
-    #     ampm = self.ampm
-    #     super().print(value)
-    #     if ampm:
-    #         self.ampm = ampm
-
 class Colon():
     """Helper class for controlling the colons. Not intended for direct use."""
     MASKS = (0x02, 0x0C)
@@ -295,7 +287,7 @@ class Colon():
 
     def __setitem__(self, key, value):
         if key > self._num_of_colons - 1:
-            raise ValueError("Trying to set a non-existant colon.")
+            raise ValueError("Trying to set a non-existent colon.")
         current = self._disp._get_buffer(0x04)
         if value:
             self._disp._set_buffer(0x04, current | self.MASKS[key])
@@ -306,5 +298,5 @@ class Colon():
 
     def __getitem__(self, key):
         if key > self._num_of_colons - 1:
-            raise ValueError("Trying to access a non-existant colon.")
+            raise ValueError("Trying to access a non-existent colon.")
         return bool(self._disp._get_buffer(0x04) & self.MASKS[key])

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -278,9 +278,10 @@ class BigSeg7x4(Seg7x4):
         if self._auto_write:
             self.show()
 
-#pylint: disable=W0212
 class Colon():
     """Helper class for controlling the colons. Not intended for direct use."""
+    #pylint: disable=protected-access
+
     MASKS = (0x02, 0x0C)
 
     def __init__(self, disp, num_of_colons=1):

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -278,6 +278,7 @@ class BigSeg7x4(Seg7x4):
         if self._auto_write:
             self.show()
 
+#pylint: disable=W0212
 class Colon():
     """Helper class for controlling the colons. Not intended for direct use."""
     MASKS = (0x02, 0x0C)


### PR DESCRIPTION
Add support for 1.2" 4-Digit 7-Segment Displays for  #17 .

These displays have some differences from the 0.56" 7-segment displays. There are no decimal places. There are two colons and an AM/PM indicator, which are controlled like this:
```python
disp.ampm = True
disp.colon[0] = True
disp.color[1] = True
```

I'm not super keen on the class name `BigSeg7x4` if someone has a better suggestion.