### PR TITLE
s/py_modules/packages/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_modules=['adafruit_ht16k33'],
+    packages=['adafruit_ht16k33'],
 )


### PR DESCRIPTION
Wasn't installing correctly.  We got a bug report on this one in the forums:

https://forums.adafruit.com/viewtopic.php?f=60&t=143138&p=707561

Looks like I let this slip through on PyPI packaging review; my bad.