### PR TITLE
segments: Add missing API for "dot" control on big 7-segments

### DIFF
--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -306,9 +306,11 @@ class BigSeg7x4(Seg7x4):
        supports displaying a limited set of characters."""
     def __init__(self, i2c, address=0x70, auto_write=True):
         super().__init__(i2c, address, auto_write)
+        # Use colon for controling two-dots indicator at the center (index 0)
+        # or the two-dots indicators at the left (index 1)
         self.colon = Colon(self, 2)
 
-    def setindicator(self, index, value):
+    def _setindicator(self, index, value):
         """ Set side LEDs (dots)
             Index is as follow :
             * 0 : two dots at the center
@@ -325,7 +327,7 @@ class BigSeg7x4(Seg7x4):
         if self._auto_write:
             self.show()
 
-    def getindicator(self, index):
+    def _getindicator(self, index):
         """ Get side LEDs (dots)
             See setindicator() for indexes
         """
@@ -333,14 +335,40 @@ class BigSeg7x4(Seg7x4):
         return self._get_buffer(0x04) & bitmask
 
     @property
+    def two_dots_center(self):
+        """The two dots at the center indicator."""
+        return bool(self._getindicator(0))
+
+    @two_dots_center.setter
+    def two_dots_center(self, value):
+        self._setindicator(0, value)
+
+    @property
+    def top_left_dot(self):
+        """The top-left dot indicator."""
+        return bool(self._getindicator(1))
+
+    @top_left_dot.setter
+    def top_left_dot(self, value):
+        self._setindicator(1, value)
+
+    @property
+    def bottom_left_dot(self):
+        """The bottom-left dot indicator."""
+        return bool(self._getindicator(2))
+
+    @bottom_left_dot.setter
+    def bottom_left_dot(self, value):
+        self._setindicator(2, value)
+
+    @property
     def ampm(self):
         """The AM/PM indicator."""
-        return bool(self.getindicator(3))
+        return bool(self._getindicator(3))
 
     @ampm.setter
     def ampm(self, value):
-        self.setindicator(3, value)
-
+        self._setindicator(3, value)
 
 class Colon():
     """Helper class for controlling the colons. Not intended for direct use."""

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -308,20 +308,39 @@ class BigSeg7x4(Seg7x4):
         super().__init__(i2c, address, auto_write)
         self.colon = Colon(self, 2)
 
+    def setindicator(self, index, value):
+        """ Set side LEDs (dots)
+            Index is as follow :
+            * 0 : two dots at the center
+            * 1 : top-left dot
+            * 2 : bottom-left dot
+            * 3 : right dot (also ampm indicator)
+        """
+        bitmask = 1 << (index + 1)
+        current = self._get_buffer(0x04)
+        if value:
+            self._set_buffer(0x04, current | bitmask)
+        else:
+            self._set_buffer(0x04, current & ~bitmask)
+        if self._auto_write:
+            self.show()
+
+    def getindicator(self, index):
+        """ Get side LEDs (dots)
+            See setindicator() for indexes
+        """
+        bitmask = 1 << (index + 1)
+        return self._get_buffer(0x04) & bitmask
+
     @property
     def ampm(self):
         """The AM/PM indicator."""
-        return bool(self._get_buffer(0x04) & 0x10)
+        return bool(self.getindicator(3))
 
     @ampm.setter
     def ampm(self, value):
-        current = self._get_buffer(0x04)
-        if value:
-            self._set_buffer(0x04, current | 0x10)
-        else:
-            self._set_buffer(0x04, current & ~0x10)
-        if self._auto_write:
-            self.show()
+        self.setindicator(3, value)
+
 
 class Colon():
     """Helper class for controlling the colons. Not intended for direct use."""

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -335,15 +335,6 @@ class BigSeg7x4(Seg7x4):
         return self._get_buffer(0x04) & bitmask
 
     @property
-    def two_dots_center(self):
-        """The two dots at the center indicator."""
-        return bool(self._getindicator(0))
-
-    @two_dots_center.setter
-    def two_dots_center(self, value):
-        self._setindicator(0, value)
-
-    @property
     def top_left_dot(self):
         """The top-left dot indicator."""
         return bool(self._getindicator(1))


### PR DESCRIPTION
There are 4 side LEDs around the 4 7-segments on 1.2" packages of HT16k33
(https://www.adafruit.com/product/1270). This commit adds an API to control
them (set and get).

There already was setter and getter to control "ampm" dot (the one at the
top-right). This API is still working but now use the new added functions.