### PR TITLE
Fixed set_digit_raw to match Python library

### DIFF
--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -240,8 +240,8 @@ class Seg14x4(HT16K33):
             bitmask = bitmask[0] << 8 | bitmask[1]
 
         # Set the digit bitmask value at the appropriate position.
-        self._set_buffer(index * 2, (bitmask >> 8) & 0xFF)
-        self._set_buffer(index * 2 + 1, bitmask & 0xFF)
+        self._set_buffer(index * 2, bitmask & 0xFF)
+        self._set_buffer(index * 2 + 1, (bitmask >> 8) & 0xFF)
 
         if self._auto_write:
             self.show()

--- a/examples/ht16k33_segments_simpletest.py
+++ b/examples/ht16k33_segments_simpletest.py
@@ -17,9 +17,9 @@ i2c = busio.I2C(board.SCL, board.SDA)
 
 # Create the LED segment class.
 # This creates a 7 segment 4 character display:
-display = segments.Seg7x4(i2c)
+#display = segments.Seg7x4(i2c)
 # Or this creates a 14 segment alphanumeric 4 character display:
-#display = segments.Seg14x4(i2c)
+display = segments.Seg14x4(i2c)
 # Finally you can optionally specify a custom I2C address of the HT16k33 like:
 #display = segments.Seg7x4(i2c, address=0x70)
 
@@ -54,10 +54,11 @@ if isinstance(display, segments.Seg7x4):
     display.set_digit_raw(3, 0b01111001)
 else:
     # 14-segment raw digits
-    display.set_digit_raw(0, 0x3F2D)
-    display.set_digit_raw(1, 0b0011111100101101)
-    display.set_digit_raw(2, (0b00111111, 0b00101101))
-    display.set_digit_raw(3, [0b00111111, 0b00101101])
+    display.set_digit_raw(0, 0x2D3F)
+    display.set_digit_raw(1, 0b0010110100111111)
+    display.set_digit_raw(2, (0b00101101, 0b00111111))
+    display.set_digit_raw(3, [0x2D, 0x3F])
+time.sleep(2)
 
 #Show a looping marquee
 display.marquee('Deadbeef 192.168.100.102... ', 0.2)

--- a/examples/ht16k33_segments_simpletest.py
+++ b/examples/ht16k33_segments_simpletest.py
@@ -17,9 +17,9 @@ i2c = busio.I2C(board.SCL, board.SDA)
 
 # Create the LED segment class.
 # This creates a 7 segment 4 character display:
-#display = segments.Seg7x4(i2c)
+display = segments.Seg7x4(i2c)
 # Or this creates a 14 segment alphanumeric 4 character display:
-display = segments.Seg14x4(i2c)
+#display = segments.Seg14x4(i2c)
 # Finally you can optionally specify a custom I2C address of the HT16k33 like:
 #display = segments.Seg7x4(i2c, address=0x70)
 


### PR DESCRIPTION
While working on the guide, I noticed I had it reversed. I fixed it here to match the Python LED Backpack library and updated the example.