### PR TITLE
Added colon property to 7-segment x 4 display

### DIFF
--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -311,6 +311,11 @@ class Seg7x4(Seg14x4):
        supports displaying a limited set of characters."""
     POSITIONS = (0, 2, 6, 8) #  The positions of characters.
 
+    def __init__(self, i2c, address=0x70, auto_write=True):
+        super().__init__(i2c, address, auto_write)
+        # Use colon for controling two-dots indicator at the center (index 0)
+        self._colon = Colon(self)
+
     def scroll(self, count=1):
         """Scroll the display by specified number of places."""
         if count >= 0:
@@ -371,6 +376,15 @@ class Seg7x4(Seg14x4):
 
         if self._auto_write:
             self.show()
+
+    @property
+    def colon(self):
+        """Simplified colon accessor"""
+        return self._colon[0]
+
+    @colon.setter
+    def colon(self, turn_on):
+        self._colon[0] = turn_on
 
 class BigSeg7x4(Seg7x4):
     """Numeric 7-segment display. It has the same methods as the alphanumeric display, but only

--- a/examples/ht16k33_segments_simpletest.py
+++ b/examples/ht16k33_segments_simpletest.py
@@ -34,6 +34,12 @@ time.sleep(2)
 display.print_hex(0xFF23)
 time.sleep(2)
 
+# Or, print the time
+display.print("12:30")
+time.sleep(2)
+
+display.colon = False
+
 # Or, can set indivdual digits / characters
 # Set the first character to '1':
 display[0] = '1'


### PR DESCRIPTION
I realized the colon class was not being used with the smaller display and added it. I used a property so users could access it with `.colon` instead of `.colon[0]`.