### PR TITLE
Fix potential issue with tuple bitmask tuple to set_digit_raw

### DIFF
--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -268,7 +268,7 @@ class Seg14x4(HT16K33):
             return
 
         if isinstance(bitmask, (tuple, list)):
-            bitmask = bitmask[0] << 8 | bitmask[1]
+            bitmask = ((bitmask[0] & 0xFF) << 8) | (bitmask[1] & 0xFF)
 
         # Set the digit bitmask value at the appropriate position.
         self._set_buffer(index * 2, bitmask & 0xFF)

--- a/examples/ht16k33_matrix_simpletest.py
+++ b/examples/ht16k33_matrix_simpletest.py
@@ -19,7 +19,7 @@ i2c = busio.I2C(board.SCL, board.SDA)
 # This creates a 16x8 matrix:
 matrix = matrix.Matrix16x8(i2c)
 # Or this creates a 16x8 matrix backpack:
-# matrix = matrix.MatrixBackpack16x8(i2c)
+#matrix = matrix.MatrixBackpack16x8(i2c)
 # Or this creates a 8x8 matrix:
 #matrix = matrix.Matrix8x8(i2c)
 # Or this creates a 8x8 bicolor matrix:


### PR DESCRIPTION
Fixes a potential issue with passing numbers > 255 as bitmask tuple to set_digit_raw. This was pointed out by @geekguy-wy in discord.