### PR TITLE
Disable matrix refresh during update using image()  (Fixes #78)

### DIFF
--- a/adafruit_ht16k33/matrix.py
+++ b/adafruit_ht16k33/matrix.py
@@ -124,10 +124,13 @@ class Matrix8x8(HT16K33):
             )
         # Grab all the pixels from the image, faster than getpixel.
         pixels = img.convert("1").load()
+        auto_write = self.auto_write
+        self._auto_write = False
         # Iterate through the pixels
         for x in range(self.columns):  # yes this double loop is slow,
             for y in range(self.rows):  #  but these displays are small!
                 self.pixel(x, y, pixels[(x, y)])
+        self._auto_write = auto_write
         if self._auto_write:
             self.show()
 

--- a/adafruit_ht16k33/matrix.py
+++ b/adafruit_ht16k33/matrix.py
@@ -217,6 +217,8 @@ class Matrix8x8x2(Matrix8x8):
             )
         # Grab all the pixels from the image, faster than getpixel.
         pixels = img.convert("RGB").load()
+        auto_write = self.auto_write
+        self._auto_write = False
         # Iterate through the pixels
         for x in range(self.columns):  # yes this double loop is slow,
             for y in range(self.rows):  #  but these displays are small!
@@ -229,5 +231,6 @@ class Matrix8x8x2(Matrix8x8):
                 else:
                     # Unknown color, default to LED off.
                     self.pixel(x, y, self.LED_OFF)
+        self._auto_write = auto_write
         if self._auto_write:
             self.show()


### PR DESCRIPTION
In both `Matrix8x8.image()` and `Matrix 8x8x2.image()`, set temporary variable to current `auto_write` state and then set `auto_write` to `False` before entering loop to update pixels in the matrix.  Once updated, restore `auto_write` state.

For consistency, used the same temporary variable naming as was done in `Matrix8x8.shift()`.

I hope I understood the request correctly... please don't hesitate to let me know if I should do anything differently!