### PR TITLE
Fix licensing of example

### DIFF
--- a/examples/ht16k33_segments_7x4customchars.py
+++ b/examples/ht16k33_segments_7x4customchars.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Alec Delaney
+# SPDX-FileCopyrightText: 2022 Alec Delaney
 #
 # SPDX-License-Identifier: MIT
 

--- a/examples/ht16k33_segments_7x4customchars.py
+++ b/examples/ht16k33_segments_7x4customchars.py
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: Alec Delaney
+#
 # SPDX-License-Identifier: MIT
 
-# Basic example of setting digits on a LED segment display.
-# This example and library is meant to work with Adafruit CircuitPython API.
-# Author: Alec Delaney
-# License: Public Domain
+"""
+Basic example of setting custom characters on a LED segment display.
+"""
 
 # Import all board pins.
 import time


### PR DESCRIPTION
Looks like I added some non-uniform licensing text, here's a fix to correct it!