### PR TITLE
minor code comment update

### DIFF
--- a/examples/ht16k33_animation_demo.py
+++ b/examples/ht16k33_animation_demo.py
@@ -16,7 +16,7 @@ from adafruit_ht16k33.animations import Animation
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
 display = Seg14x4(i2c, auto_write=False)
-#   Brightness of the display (0 to 15)
+#   Brightness of the display (0.0 to 1.0)
 display.brightness = 0.3
 
 ani = Animation(display)


### PR DESCRIPTION
Noticed a simpletest code comment said brightness was 0-15.  Pretty sure it should be (0.0 to 1.0) across all segment types now. 

[Docs on HT16K33.brightness](https://docs.circuitpython.org/projects/ht16k33/en/latest/api.html#adafruit_ht16k33.ht16k33.HT16K33.brightness)

After further investigation the code comment is a hold over from when brightness used to be an integer from 0-15 [introduced here](https://github.com/adafruit/Adafruit_CircuitPython_HT16K33/blob/27ab7c7605b1afe8350bf02b4344434c0d39d8ae/examples/ht16k33_animation_demo.py) 4 years ago.

Just seems that particular code comment wasn't changed when brightness was switched from int to float in [this commit](https://github.com/adafruit/Adafruit_CircuitPython_HT16K33/blob/92d73acb72f8e27a930cbcd725d8b91dfaf412e3/examples/ht16k33_animation_demo.py).