### PR TITLE
Fix color swapping during shift()

### DIFF
--- a/adafruit_ht16k33/matrix.py
+++ b/adafruit_ht16k33/matrix.py
@@ -245,7 +245,7 @@ class Matrix8x8x2(Matrix8x8):
             super()._pixel(y, x, (color >> 1) & 0x01)
             super()._pixel(y + 8, x, (color & 0x01))
         else:
-            return super()._pixel(y, x) | super()._pixel(y + 8, x) << 1
+            return super()._pixel(y, x)  << 1 | super()._pixel(y + 8, x)
         return None
 
     def fill(self, color: int) -> None:

--- a/adafruit_ht16k33/matrix.py
+++ b/adafruit_ht16k33/matrix.py
@@ -245,7 +245,7 @@ class Matrix8x8x2(Matrix8x8):
             super()._pixel(y, x, (color >> 1) & 0x01)
             super()._pixel(y + 8, x, (color & 0x01))
         else:
-            return super()._pixel(y, x)  << 1 | super()._pixel(y + 8, x)
+            return super()._pixel(y, x) << 1 | super()._pixel(y + 8, x)
         return None
 
     def fill(self, color: int) -> None:


### PR DESCRIPTION
This fixes the color swapping during shift() as noted in https://github.com/adafruit/Adafruit_CircuitPython_HT16K33/issues/102