### PR TITLE
Don't reset scroll index if loop is False

### DIFF
--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -398,14 +398,13 @@ class Seg14x4(HT16K33):
 
                         self.print(text[self._nb_scroll_index])
                         self._nb_prev_char_is_dot = text[self._nb_scroll_index] == "."
+                    elif loop:
+                        self._nb_scroll_index = -1
+                        if space_between:
+                            self._last_nb_scroll_time = now
+                            self.print(" ")
                     else:
-                        if loop:
-                            self._nb_scroll_index = -1
-                            if space_between:
-                                self._last_nb_scroll_time = now
-                                self.print(" ")
-                        else:
-                            return True
+                        return True
             else:
                 # different text
                 self._nb_scroll_index = 0

--- a/adafruit_ht16k33/segments.py
+++ b/adafruit_ht16k33/segments.py
@@ -399,8 +399,8 @@ class Seg14x4(HT16K33):
                         self.print(text[self._nb_scroll_index])
                         self._nb_prev_char_is_dot = text[self._nb_scroll_index] == "."
                     else:
-                        self._nb_scroll_index = -1
                         if loop:
+                            self._nb_scroll_index = -1
                             if space_between:
                                 self._last_nb_scroll_time = now
                                 self.print(" ")


### PR DESCRIPTION
If we reset the scroll index, we keep looping because the scroll index (-1) isn't at the end of the text.